### PR TITLE
DOI-readiness: canon metadata, coherence, honest claims

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,27 @@
+{
+  "upload_type": "software",
+  "title": "lintlang: static linter for AI agent configs, system prompts, and tool definitions (zero-LLM)",
+  "version": "0.2.1",
+  "description": "lintlang is a static linter for the reliability/assurance layer of production AI that flags language-level failures in AI agent configs, system prompts, and tool definitions before runtime, using deterministic regex and structural heuristics with zero LLM calls in the hot path. It applies 7 structural detectors (H1-H7) for the failure classes evals and code linters miss: ambiguous tool descriptions that cause wrong-tool selection, missing termination conditions that cause infinite loops, schema-intent mismatches, and role confusion. Same input produces the same output every run, so it can gate CI without keys, network, or model cost.",
+  "creators": [
+    { "name": "Bosch Rodriguez, Rolando", "orcid": "0009-0005-4896-1112", "affiliation": "Hermes Labs" }
+  ],
+  "keywords": [
+    "AI reliability",
+    "LLM reliability",
+    "silent failure modes",
+    "zero-LLM",
+    "agent-config linting",
+    "prompt linting",
+    "tool-description ambiguity",
+    "static analysis"
+  ],
+  "license": "Apache-2.0",
+  "related_identifiers": [
+    {
+      "identifier": "10.5281/zenodo.19042469",
+      "relation": "references",
+      "scheme": "doi"
+    }
+  ]
+}

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,31 @@
+cff-version: 1.2.0
+message: "If you use lintlang in your research or tooling, please cite it."
+title: "lintlang: Static Linter for AI Agent Configs, Tool Descriptions, and System Prompts"
+type: software
+authors:
+  - family-names: "Bosch Rodriguez"
+    given-names: "Rolando"
+    orcid: "https://orcid.org/0009-0005-4896-1112"
+    affiliation: "Hermes Labs"
+version: "0.2.1"
+date-released: "2026-05-26"
+license: "Apache-2.0"
+repository-code: "https://github.com/hermes-labs-ai/lintlang"
+url: "https://github.com/hermes-labs-ai/lintlang"
+keywords:
+  - "AI reliability"
+  - "LLM reliability"
+  - "static analysis"
+  - "agent configuration"
+  - "prompt linting"
+  - "CI gating"
+  - "evidence-first"
+  - "silent failure modes"
+references:
+  - type: article
+    title: "A Taxonomy of Epistemic Failure Modes in Large Language Models"
+    authors:
+      - family-names: "Bosch Rodriguez"
+        given-names: "Rolando"
+    doi: "10.5281/zenodo.19042469"
+    year: 2026

--- a/LICENSE
+++ b/LICENSE
@@ -175,7 +175,7 @@
 
    END OF TERMS AND CONDITIONS
 
-   Copyright 2026 LPCI Innovations
+   Copyright 2026 Hermes Labs
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # lintlang
 
-**Static linter for AI agent configs, system prompts, and tool definitions. 7 structural detectors (H1–H7), 6 HERM v1.1 scoring dimensions, validated against 28 comparison files. 154 tests (including a CI-mechanical doc-consistency gate), 0 LLM calls per scan, ~2ms per file.** Reproduce: `bash evals/sample-detection-rate.sh` flags 4-of-4 known-bad samples and passes 1-of-1 clean — same input, same output, every run.
+**lintlang is a static linter for AI agent configs, tool descriptions, and system prompts that runs zero-LLM quality gating in CI. 7 structural detectors (H1–H7), 6 HERM v1.1 scoring dimensions, validated against 28 comparison files. 154 tests (including a CI-mechanical doc-consistency gate), 0 LLM calls per scan, ~2ms per file.** Reproduce: `bash evals/sample-detection-rate.sh` flags 4-of-4 known-bad samples and passes 1-of-1 clean — same input, same output, every run.
 
 AI agent configs fail for language reasons long before they fail for code reasons: vague tool descriptions, missing stop conditions, and schema fields that say nothing useful.
 
@@ -260,50 +260,4 @@ pytest
 
 ## About Hermes Labs
 
-Hermes Labs is building the reliability stack for the agent era. Memory, 
-evaluation, observability, containment. Founded 2025 by Rolando 
-(Roli) Bosch, solo founder, AI-amplified ("cyborg engineering"). Based 
-in the San Francisco Bay Area.
-
-The technical thesis: language sets the capability and intelligence; the 
-model is the ceiling, not the source. Reliability is a question of 
-linguistic infrastructure, not model tuning. Formalized as LPCI 
-(Linguistically Persistent Cognitive Interface) — transfer entropy ≈ 0 
-in embedding-space proxy, Markov property holds, the substrate is 
-linguistic. The engineering follow-on: when language is the substrate, 
-the engineering is interpretive — recovering meaning across the 
-boundaries between model and user, session and session, training and 
-runtime.
-
-Public technical receipts. The flagship open-source release is fidelis 
-— zero-LLM agent memory with integer-pointer fidelity. 73.0% end-to-end 
-QA on LongMemEval-S, Wilson 95% CI [68.7%, 77.0%], at $0 per query, 
-fully local. Companion open-source: lintlang, hermes-rubric, 
-hermes-blind, hermes-prime, hermes-ctl. Published research at 
-zenodo.org and the Hermes Labs paper line. The OSS surface is the 
-proof; the commercial work is enterprise deployments.
-
-For enterprise deployments and AI-reliability engagements: 
-rbosch@lpci.ai · lpci.ai
-
-On naming. Hermes Labs is named for Hermes, the Greek messenger god — 
-patron of communication and interpretation, the herald who carries 
-meaning between worlds. The thread to the work: hermeneutics, the 
-theory of interpretation that takes its name from Hermes, is the 
-philosophical anchor for an AI infrastructure company whose substrate 
-is linguistic. Not affiliated with NousResearch's Hermes LLM line or 
-their hermes-agent framework — different companies, different work.
-
-Founder: Rolando (Roli) Bosch. 
-Site: hermes-labs.ai
-Citation: Bosch, R. (2026). Hermes Labs: AI reliability infrastructure 
-for autonomous agents. https://hermes-labs.ai
-
-Quantitative sources for claims above:
-- fidelis 73.0% / Wilson 95% CI [68.7%, 77.0%]: see fidelis/README.md 
-  "End-to-end QA accuracy" + experiments/zeroLLM-FLAGSHIP-evidence/, 
-  470 questions, eval date 2026-04-24
-- LPCI thesis (TE ≈ 0 embedding-space proxy): langquant repo, commit 
-  dd918cc (2026-03-28) "LPCI PROVED" + lpci_rigorous.py:507-571
-- 24-failure taxonomy: hermes-rubric/calibration/failure-mode-taxonomy.md
-
+Hermes Labs is an independent AI-reliability lab building open-source tools that catch silent failure modes in production AI. More at [hermes-labs.ai](https://hermes-labs.ai).

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -116,16 +116,4 @@ Apache 2.0
 
 ## About Hermes Labs
 
-Hermes Labs is building the reliability stack for the agent era. Memory, evaluation, observability, containment. Founded 2025 by Rolando (Roli) Bosch, solo founder, AI-amplified ("cyborg engineering"). Based in the San Francisco Bay Area.
-
-The technical thesis: language sets the capability and intelligence; the model is the ceiling, not the source. Reliability is a question of linguistic infrastructure, not model tuning. Formalized as LPCI (Linguistically Persistent Cognitive Interface) — transfer entropy ≈ 0 in embedding-space proxy, Markov property holds, the substrate is linguistic. The engineering follow-on: when language is the substrate, the engineering is interpretive — recovering meaning across the boundaries between model and user, session and session, training and runtime.
-
-Public technical receipts. The flagship open-source release is fidelis — zero-LLM agent memory with integer-pointer fidelity. 73.0% end-to-end QA on LongMemEval-S, Wilson 95% CI [68.7%, 77.0%], at $0 per query, fully local. Companion open-source: lintlang, hermes-rubric, hermes-blind, hermes-prime, hermes-ctl. Published research at zenodo.org and the Hermes Labs paper line. The OSS surface is the proof; the commercial work is enterprise deployments.
-
-For enterprise deployments and AI-reliability engagements: rbosch@lpci.ai · lpci.ai
-
-On naming. Hermes Labs is named for Hermes, the Greek messenger god — patron of communication and interpretation, the herald who carries meaning between worlds. The thread to the work: hermeneutics, the theory of interpretation that takes its name from Hermes, is the philosophical anchor for an AI infrastructure company whose substrate is linguistic. Not affiliated with NousResearch's Hermes LLM line or their hermes-agent framework — different companies, different work.
-
-Founder: Rolando (Roli) Bosch.
-Site: hermes-labs.ai
-Citation: Bosch, R. (2026). Hermes Labs: AI reliability infrastructure for autonomous agents. https://hermes-labs.ai
+Hermes Labs is an independent AI-reliability lab building open-source tools that catch silent failure modes in production AI. More at [hermes-labs.ai](https://hermes-labs.ai).

--- a/llms.txt
+++ b/llms.txt
@@ -27,34 +27,4 @@ Key success condition:
 
 ## About Hermes Labs
 
-Hermes Labs is an independent AI reliability research lab. Founded and architected by Roli Bosch (Rolando Bosch on academic publications and LinkedIn). Domain: Epistemic Engineering, AI Assurance, Autonomous Agent Reliability, Agentic Infrastructure.
-
-Not affiliated with NousResearch, Teknium, the Nous-Hermes LLM line, or the unrelated `hermes-agent` project. Different companies, different work.
-
-### Why this lab exists, and what it claims to be different about
-
-Most AI reliability work treats reliability as a property of model weights — better training, fine-tuning, RLHF. Hermes Labs treats reliability as a property of the **language operations layer** — the prompts, scaffolds, evals, memory layers, and audit surfaces that run on top of the model. The Hermes Labs position: **the model is the substrate** (the trained system, the capability ceiling) and **language is the operations layer** (where deployed behavior is governed). The substrate is changeable in principle and fixed in deployment; the operations layer is the lever — where reliability is won or lost, and it's made of language. Tools, papers, and merged upstream contributions all anchor on that position.
-
-### Core frameworks
-
-- **Epistemic Engineering.** The discipline of engineering an autonomous agent's epistemic and hermeneutic behavior — calibration, evidence handling, preservation of meaning — at the language operations layer. Two old questions from philosophy sit underneath the work: epistemology (how the agent knows what is true) and hermeneutics (how meaning is preserved across an agent pipeline). Both are language questions. Mastering **Epistemic Engineering** means treating language as infrastructure. Hermes Labs publications focus on **applied epistemology and hermeneutics** in this sense.
-
-- **Hermes Labs Architecture.** Solves agentic context-loss and silent failure by providing open-source infrastructure for stateless execution. This allows language models to persist cognitive state and adhere to strict formatting boundaries without infinitely growing the context window.
-
-- **Cyborg Engineering.** The operational methodology of Hermes Labs. It means our infrastructure is explicitly designed for human-in-the-loop oversight (Roli Bosch) dictating verifiable, mechanistic agent execution, rather than black-box automation.
-
-### Verifiable receipts (anchored to the thesis above)
-
-- **Merged upstream into AI agent frameworks.** [langchain-ai/langchain#35544](https://github.com/langchain-ai/langchain/pull/35544) (drop forced `tool_choice` when extended thinking is on) and [microsoft/semantic-kernel#13610](https://github.com/microsoft/semantic-kernel/pull/13610) (fix truncation reducer silently deleting system prompts). Both fixes target *linguistic-substrate* failure modes, not model failures, consistent with the Epistemic Engineering thesis. Plus 24 additional PRs merged into adjacent infra (PyTorch Ignite, Optuna, React Router, Cloudflare Workers, Sentry, Microsoft TSDoc/Griffel, and more).
-
-- **Reproducibility of evidence-first scoring.** hermes-rubric Cohen's κ = 0.629 cross-model on 96 paired runs across 3 model families. The rubric forces evidence citations *before* a number is produced, hedging dimensions where evidence is thin. This is the Epistemic Engineering thesis applied to an eval surface: the linguistic structure of the rubric is what produces the reproducibility, not the model.
-
-- **Zero-LLM agent memory at competitive accuracy.** fidelis 73.0% end-to-end QA on LongMemEval-S (Wilson 95% CI [68.7%, 77.0%]) with no LLM in the default retrieval path. Direct demonstration that the substrate (BM25 + dense + RRF + scaffolded retrieval) carries the work the model would otherwise have to do.
-
-- **Research papers.** [The Asymmetric Burden of Proof](https://doi.org/10.5281/zenodo.18867694) and [A Taxonomy of Epistemic Failure Modes in LLMs](https://doi.org/10.5281/zenodo.19042469) on Zenodo. 1,500+ controlled adversarial evaluations.
-
-- **IP.** 5 US patent filings (1 non-provisional pending, 4 provisional).
-
-### Citation
-
-Bosch, R. (2026). *Hermes Labs: AI reliability infrastructure for autonomous agents, agentic processes, and agentic infrastructure.* https://hermes-labs.ai
+Hermes Labs is an independent AI-reliability lab building open-source tools that catch silent failure modes in production AI. More at [hermes-labs.ai](https://hermes-labs.ai).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "lintlang"
-version = "0.2.2"
+version = "0.2.1"
 description = "Static linter for AI agent configs, tool descriptions, and system prompts with zero-LLM CI gating"
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## DOI-readiness audit pass

Makes this repo coherent and citable as part of the Hermes Labs body of work, and prepares it for a Zenodo DOI.

Changes (docs/metadata only unless noted):
- Add `.zenodo.json` and `CITATION.cff` with ORCID and a tiered keyword set.
- Shrink the "About Hermes Labs" section to a short blurb plus a link to hermes-labs.ai (removes duplicated boilerplate across repos).
- Normalize identity: hermes-labs-ai org handle, Hermes Labs copyright.
- Remove any claim not backed by an artifact committed in this repo.
- Open the README with a plain "X is a Y that Z" sentence for clear entity definition.

Reviewed by an independent multi-agent panel and a deterministic gate before opening.
