### PR TITLE
ci: update core GitHub Actions to v7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,10 @@ jobs:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: "3.12"
 


### PR DESCRIPTION
## What changed

- update `actions/checkout` to v7 in CI and publishing
- update `actions/setup-python` to v7 in CI and publishing
- preserve the Python 3.10-3.13 matrix, pip cache, triggers, permissions, build commands, and release behavior

## Why

The existing Dependabot PRs #22 and #24 remain relevant but are based on stale branches and old hosted checks. This combines their still-needed four-line maintenance change on current `main`, so the interaction is validated once.

This does not change LintLang package code, CLI behavior, supported Python versions, or the version used by existing adopters. The `pip-install` input removed upstream from setup-python v7 was never used here; normal `pip install` commands remain unchanged.

## Validation

- `pytest -q`: 240 tests and 76 subtests passed
- `ruff check src/ tests/`: passed
- fixture regression: 4/4 bad fixtures flagged; clean fixture passed
- clean-sample self-scan: passed
- `git diff --check`: passed
- hosted Python 3.10-3.13 CI required before readiness

Draft for owner review. Do not close #22 or #24 until this replacement is reviewed and green.
