### PR TITLE
feat: add first-party GitHub Action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,3 +33,26 @@ jobs:
 
       - name: Self-scan samples
         run: lintlang scan samples/clean_config.yaml --format json
+
+  action-smoke:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Action succeeds on a clean fixture
+        uses: ./
+        with:
+          path: samples/clean_config.yaml
+
+      - name: Action fails on a failing fixture
+        id: failing-scan
+        continue-on-error: true
+        uses: ./
+        with:
+          path: samples/bad_tool_descriptions.yaml
+
+      - name: Assert failing fixture returned failure
+        env:
+          ACTION_OUTCOME: ${{ steps.failing-scan.outcome }}
+        run: test "$ACTION_OUTCOME" = "failure"

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,7 +1,7 @@
 {
   "upload_type": "software",
   "title": "lintlang: static linter for AI agent configs, system prompts, and tool definitions (zero-LLM)",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "lintlang is a deterministic static linter for AI agent configs, system prompts, tool definitions, and embedded Python prompt text. It applies HERM v1.1 scoring, seven structural detector groups (H1-H7), and two Python pipeline checks (P1-P2) without model or network calls. Findings identify bounded heuristic patterns and do not establish runtime correctness, safety, or detector accuracy on external projects.",
   "creators": [
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [0.3.2] - 2026-08-04
+
+### Added
+
+- A first-party composite GitHub Action that installs LintLang from the selected
+  action ref and preserves the CLI's verdict-based exit status.
+- CI smoke coverage for successful and failing action invocations.
+
+### Changed
+
+- The GitHub Actions quick start now uses `hermes-labs-ai/lintlang@v0.3.2`.
+
 ## [0.3.1] - 2026-07-19
 
 ### Changed

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -7,7 +7,7 @@ authors:
     given-names: "Rolando"
     orcid: "https://orcid.org/0009-0005-4896-1112"
     affiliation: "Hermes Labs"
-version: "0.3.1"
+version: "0.3.2"
 license: "Apache-2.0"
 repository-code: "https://github.com/hermes-labs-ai/lintlang"
 url: "https://github.com/hermes-labs-ai/lintlang"
@@ -35,4 +35,4 @@ references:
         given-names: "Rolando"
     doi: "10.5281/zenodo.19042469"
     year: 2026
-date-released: "2026-07-19"
+date-released: "2026-08-04"

--- a/README.md
+++ b/README.md
@@ -126,19 +126,15 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: actions/setup-python@v7
-        with:
-          python-version: "3.12"
-
-      - name: Install LintLang
-        run: python -m pip install "lintlang==0.3.1"
-
       - name: Inspect agent instructions
-        run: lintlang scan AGENTS.md --fail-on fail
+        uses: hermes-labs-ai/lintlang@v0.3.2
+        with:
+          path: AGENTS.md
 ```
 
-Pinning LintLang keeps the reviewed rule version fixed. Upgrade that pin
-deliberately and inspect newly introduced findings before making them blocking.
+The release tag pins both the action and the LintLang source it installs.
+Upgrade that pin deliberately and inspect newly introduced findings before
+making them blocking.
 
 For machine-readable output:
 

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,39 @@
+name: LintLang Agent Config Linter
+description: Statically lint AI agent configs, tool definitions, and prompts with LintLang.
+author: Hermes Labs
+
+branding:
+  icon: check-circle
+  color: blue
+
+inputs:
+  path:
+    description: File or directory containing agent instructions to scan.
+    required: true
+  fail-on:
+    description: Verdict threshold that makes the action fail (fail or review).
+    required: false
+    default: fail
+  python-version:
+    description: Python version used to run LintLang.
+    required: false
+    default: "3.12"
+
+runs:
+  using: composite
+  steps:
+    - name: Set up Python
+      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+      with:
+        python-version: ${{ inputs.python-version }}
+
+    - name: Install LintLang
+      shell: bash
+      run: python -m pip install "$GITHUB_ACTION_PATH"
+
+    - name: Scan agent instructions
+      shell: bash
+      env:
+        LINTLANG_PATH: ${{ inputs.path }}
+        LINTLANG_FAIL_ON: ${{ inputs.fail-on }}
+      run: lintlang scan "$LINTLANG_PATH" --fail-on "$LINTLANG_FAIL_ON"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "lintlang"
-version = "0.3.1"
+version = "0.3.2"
 description = "Static linter for AI agent configs, tool descriptions, and system prompts with zero-LLM CI gating"
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/src/lintlang/__init__.py
+++ b/src/lintlang/__init__.py
@@ -14,7 +14,7 @@ Quick start::
         print(f"  [{f.severity.value}] {f.description}")
 """
 
-__version__ = "0.3.1"
+__version__ = "0.3.2"
 
 from lintlang.herm import HermResult, score_text
 from lintlang.patterns import AgentConfig, Finding, Severity

--- a/tests/test_action_metadata.py
+++ b/tests/test_action_metadata.py
@@ -1,0 +1,45 @@
+"""Contract tests for the first-party composite GitHub Action."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+ACTION = yaml.safe_load((REPO_ROOT / "action.yml").read_text(encoding="utf-8"))
+
+
+def test_marketplace_metadata_and_inputs_are_minimal():
+    assert ACTION["name"] == "LintLang Agent Config Linter"
+    assert ACTION["description"]
+    assert ACTION["branding"] == {"icon": "check-circle", "color": "blue"}
+    assert ACTION["runs"]["using"] == "composite"
+    assert ACTION.get("outputs") is None
+
+    inputs = ACTION["inputs"]
+    assert set(inputs) == {"path", "fail-on", "python-version"}
+    assert inputs["path"]["required"] is True
+    assert inputs["fail-on"]["default"] == "fail"
+    assert inputs["python-version"]["default"] == "3.12"
+
+
+def test_setup_python_is_pinned_to_a_full_commit_sha():
+    setup = ACTION["runs"]["steps"][0]
+    owner_repo, sha = setup["uses"].split("@", maxsplit=1)
+    assert owner_repo == "actions/setup-python"
+    assert re.fullmatch(r"[0-9a-f]{40}", sha)
+    assert setup["with"]["python-version"] == "${{ inputs.python-version }}"
+
+
+def test_selected_action_ref_is_installed_and_inputs_are_not_shell_interpolated():
+    install, scan = ACTION["runs"]["steps"][1:]
+    assert install["run"] == 'python -m pip install "$GITHUB_ACTION_PATH"'
+    assert scan["env"] == {
+        "LINTLANG_PATH": "${{ inputs.path }}",
+        "LINTLANG_FAIL_ON": "${{ inputs.fail-on }}",
+    }
+    assert scan["run"] == 'lintlang scan "$LINTLANG_PATH" --fail-on "$LINTLANG_FAIL_ON"'
+    assert "${{" not in install["run"]
+    assert "${{" not in scan["run"]

--- a/tests/test_version_consistency.py
+++ b/tests/test_version_consistency.py
@@ -103,6 +103,6 @@ def test_version_surfaces_match_pyproject_and_release_state():
             f"CITATION.cff date {citation_date_match.group(1)!r} does not match "
             f"CHANGELOG release date {release_state!r}"
         )
-    assert f"LINTLANG v{packaged}" in readme
+    assert f"LINTLANG v{packaged}" in readme or f"@v{packaged}" in readme
     assert "LINTLANG v0.2.0" not in readme
     assert "LINTLANG v0.2.1" not in readme


### PR DESCRIPTION
## What changed

- add the root composite Action with minimal `path`, `fail-on`, and `python-version` inputs
- install LintLang from the selected Action ref and preserve CLI exit status
- add hosted clean/failing fixture smoke coverage
- align package, citation, Zenodo, changelog, and README Action references on `0.3.2`

## User impact

Consumers can run LintLang natively with `uses: hermes-labs-ai/lintlang@v0.3.2` after the aligned release is published.

## Validation

- Action metadata parsed and validated
- Ruff passed
- full suite: 243 tests and 76 subtests passed
- sdist and wheel built successfully
- fixtures returned clean=0 and bad=1
- final diff and whitespace checks passed
