### PR TITLE
Add uvx, pipx, and native pre-commit adoption paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,10 @@ jobs:
       - name: Run tests
         run: pytest --tb=short -q
 
+      - name: Exercise the pre-commit consumer hook
+        if: matrix.python-version == '3.12'
+        run: pre-commit try-repo . lintlang --files AGENTS.md --verbose
+
       - name: Self-scan samples
         run: lintlang scan samples/clean_config.yaml --format json
 

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,10 @@
+- id: lintlang
+  name: LintLang agent instruction review
+  description: Statically lint selected AI agent configs, tool definitions, and prompts.
+  entry: lintlang scan
+  language: python
+  args:
+    - AGENTS.md
+  pass_filenames: false
+  always_run: true
+  verbose: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,15 @@
 - A first-party composite GitHub Action that installs LintLang from the selected
   action ref and preserves the CLI's verdict-based exit status.
 - CI smoke coverage for successful and failing action invocations.
+- A native pre-commit hook that visibly reviews explicit repository-owned
+  instruction paths without blocking on heuristic verdicts by default.
 
 ### Changed
 
 - The GitHub Actions quick start now uses `hermes-labs-ai/lintlang@v0.3.2`.
+- The quick start now includes exercised `uvx` and isolated `pipx` paths.
+- Repositories can opt into blocking pre-commit `FAIL` findings after reviewing
+  their baseline.
 
 ## [0.3.1] - 2026-07-19
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,24 @@ API, telemetry, or network calls.
 
 ## Quick start
 
-Install from PyPI:
+Run once without installing, using [uv](https://docs.astral.sh/uv/):
+
+```bash
+uvx lintlang scan AGENTS.md
+```
+
+For a persistent command in an isolated environment, use
+[pipx](https://pipx.pypa.io/stable/):
+
+```bash
+pipx install lintlang
+lintlang scan AGENTS.md
+```
+
+If pipx's app directory is not on `PATH`, run `pipx ensurepath`, open a new
+shell, and retry the scan.
+
+Or install from PyPI into the current Python environment:
 
 ```bash
 python -m pip install lintlang
@@ -135,6 +152,40 @@ jobs:
 The release tag pins both the action and the LintLang source it installs.
 Upgrade that pin deliberately and inspect newly introduced findings before
 making them blocking.
+
+## Add it to pre-commit
+
+Add the hook to `.pre-commit-config.yaml` with the explicit instruction paths
+to scan:
+
+```yaml
+repos:
+  - repo: https://github.com/hermes-labs-ai/lintlang
+    rev: v0.3.2
+    hooks:
+      - id: lintlang
+        args: [AGENTS.md]
+```
+
+Activate it and test the configured paths:
+
+```bash
+pre-commit install
+pre-commit run lintlang
+```
+
+Replace or extend `args` with the prompt, tool-definition, agent-configuration,
+or supported directory paths your repository owns. The hook scans only those
+configured paths and reports findings without blocking on a verdict by default.
+After reviewing the repository's baseline, opt into blocking `FAIL` findings:
+
+```yaml
+hooks:
+  - id: lintlang
+    args: [AGENTS.md, --fail-on, fail]
+```
+
+Missing, unreadable, or malformed configured inputs still return nonzero.
 
 For machine-readable output:
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -12,6 +12,24 @@ No LLM calls. No API keys. No network access. Static analysis uses regex, struct
 
 ## Install
 
+Run once without installing:
+
+```
+uvx lintlang scan AGENTS.md
+```
+
+Install as an isolated persistent command:
+
+```
+pipx install lintlang
+lintlang scan AGENTS.md
+```
+
+If pipx's app directory is not on `PATH`, run `pipx ensurepath`, open a new
+shell, and retry the scan.
+
+Install into the current Python environment:
+
 ```
 pip install lintlang
 ```
@@ -120,11 +138,28 @@ automatically normalized.
 
 GitHub Actions:
 ```yaml
-- name: Lint agent configs
-  run: |
-    pip install lintlang
-    lintlang scan configs/ --fail-on fail
+- uses: actions/checkout@v7
+- uses: hermes-labs-ai/lintlang@v0.3.2
+  with:
+    path: configs/
 ```
+
+Add to `.pre-commit-config.yaml`:
+```yaml
+repos:
+  - repo: https://github.com/hermes-labs-ai/lintlang
+    rev: v0.3.2
+    hooks:
+      - id: lintlang
+        args: [AGENTS.md]
+```
+
+Activate and test it with `pre-commit install` and `pre-commit run lintlang`.
+
+The pre-commit hook reports verdicts without blocking by default. After
+reviewing the repository baseline, use
+`args: [AGENTS.md, --fail-on, fail]` to block `FAIL` findings. Configured input
+errors remain blocking.
 
 Exit codes: 0 = pass, 1 = findings matched --fail-on threshold or error.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ Changelog = "https://github.com/hermes-labs-ai/lintlang/blob/main/CHANGELOG.md"
 [project.optional-dependencies]
 dev = [
     "hatchling>=1.27",
+    "pre-commit>=4.5,<5",
     "pytest>=9.0.3",
     "pytest-cov>=5.0",
     "ruff>=0.9",

--- a/tests/test_precommit_metadata.py
+++ b/tests/test_precommit_metadata.py
@@ -1,0 +1,37 @@
+"""Contract tests for the native pre-commit hook."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+HOOKS = yaml.safe_load((REPO_ROOT / ".pre-commit-hooks.yaml").read_text(encoding="utf-8"))
+
+
+def test_precommit_hook_is_explicit_and_advisory_by_default():
+    assert len(HOOKS) == 1
+    hook = HOOKS[0]
+
+    assert hook["id"] == "lintlang"
+    assert hook["entry"] == "lintlang scan"
+    assert hook["language"] == "python"
+    assert hook["args"] == ["AGENTS.md"]
+    assert hook["pass_filenames"] is False
+    assert hook["always_run"] is True
+    assert hook["verbose"] is True
+
+
+def test_public_docs_show_exercised_install_and_hook_paths():
+    readme = (REPO_ROOT / "README.md").read_text(encoding="utf-8")
+    reference = (REPO_ROOT / "llms-full.txt").read_text(encoding="utf-8")
+
+    for text in (readme, reference):
+        assert "uvx lintlang scan AGENTS.md" in text
+        assert "pipx install lintlang" in text
+        assert "pipx ensurepath" in text
+        assert "repo: https://github.com/hermes-labs-ai/lintlang" in text
+        assert "rev: v0.3.2" in text
+        assert "id: lintlang" in text
+        assert "args: [AGENTS.md, --fail-on, fail]" in text


### PR DESCRIPTION
## What changed

- document one-shot `uvx` and persistent isolated `pipx` usage
- add a native pre-commit hook over explicit repository-owned instruction paths
- keep findings advisory by default, with documented `--fail-on fail` opt-in
- keep missing or unreadable configured inputs fail-closed
- exercise the real hook through `pre-commit try-repo` on Python 3.12 CI
- align README, changelog, `llms-full.txt`, development dependencies, and contract tests

## Why

This reduces first-use friction and turns LintLang into an optional recurring repository check without making heuristic findings unexpectedly block every commit. Repositories can review their baseline before deliberately enabling failure thresholds.

## Validation

- `pytest -q`: 245 passed, 76 subtests passed
- `ruff check src/ tests/`: passed
- pre-commit manifest validation: passed
- exact-revision `pre-commit try-repo`: advisory findings visible, exit 0
- explicit `--fail-on fail`: exit 1 on the known failing fixture
- missing configured path: exit 1
- wheel and sdist built as 0.3.2
- fresh-maintainer black-box review: PASS_READY_TO_PUSH

The documented `rev: v0.3.2` becomes resolvable when the aligned release tag is published after merge and hosted verification.
