### PR TITLE
ci: use PyPI trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,9 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
 
     steps:
       - uses: actions/checkout@v7
@@ -24,5 +27,3 @@ jobs:
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
## What changed

- publish releases to PyPI through the existing Trusted Publisher
- bind the publishing job to the `pypi` environment
- remove the long-lived `PYPI_API_TOKEN` credential from the workflow

## Why

PyPI already has an active Trusted Publisher for `lintlang`. The workflow still used token authentication, so it could not use that credential-free publishing path.

## Validation

- workflow YAML parses successfully
- `actionlint` validation where available
- `git diff --check`
- GitHub `pypi` environment exists
