### PR TITLE
docs: cite the Tool Differentia technical note

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,23 @@ documents LintLang H1.6, the bounded pairwise check for tool descriptions that
 do not supply an analyzed distinction from a neighboring tool. It is a
 technical note, not a semantic-equivalence proof or a runtime-selection
 evaluation. Cite the archived Version 1.0 record at
-[10.5281/zenodo.21817244](https://doi.org/10.5281/zenodo.21817244).
+[10.5281/zenodo.21817244](https://doi.org/10.5281/zenodo.21817244):
+
+```bibtex
+@misc{bosch2026tooldifferentia,
+  author       = {Bosch, Rolando},
+  title        = {Tool Differentia: Relational Static Analysis for AI Agent
+                  Tool Descriptions},
+  year         = {2026},
+  publisher    = {Zenodo},
+  doi          = {10.5281/zenodo.21817244},
+  url          = {https://doi.org/10.5281/zenodo.21817244},
+  note         = {Technical note}
+}
+```
+
+See [hermes-publications/papers/tool-differentia](https://github.com/hermes-labs-ai/hermes-publications/tree/main/papers/tool-differentia)
+for the full evidence boundary.
 
 ## Quick start
 
@@ -311,30 +327,6 @@ inspects one present instruction plus explicit context.
 - [Contributing](CONTRIBUTING.md)
 - [Report an issue or disputed finding](https://github.com/hermes-labs-ai/lintlang/issues)
 - [Security policy](SECURITY.md)
-
-## Citation
-
-H1.6's method is described in a technical note:
-
-Bosch, R. (2026). *Tool Differentia: Relational Static Analysis for AI Agent
-Tool Descriptions.* Zenodo.
-[10.5281/zenodo.21817244](https://doi.org/10.5281/zenodo.21817244)
-
-```bibtex
-@misc{bosch2026tooldifferentia,
-  author       = {Bosch, Rolando},
-  title        = {Tool Differentia: Relational Static Analysis for AI Agent
-                  Tool Descriptions},
-  year         = {2026},
-  publisher    = {Zenodo},
-  doi          = {10.5281/zenodo.21817244},
-  url          = {https://doi.org/10.5281/zenodo.21817244},
-  note         = {Technical note}
-}
-```
-
-See [hermes-publications/papers/tool-differentia](https://github.com/hermes-labs-ai/hermes-publications/tree/main/papers/tool-differentia)
-for the full evidence boundary.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -246,6 +246,11 @@ lintlang patterns
 
 See the [full technical reference](llms-full.txt) for detector details.
 
+H1.6's method is described in a technical note: Bosch, R. (2026). *Tool
+Differentia: Relational Static Analysis for AI Agent Tool Descriptions.*
+Zenodo. [10.5281/zenodo.21817244](https://doi.org/10.5281/zenodo.21817244).
+See [Citation](#citation) below.
+
 ## Where it fits
 
 ```text
@@ -297,6 +302,30 @@ inspects one present instruction plus explicit context.
 - [Contributing](CONTRIBUTING.md)
 - [Report an issue or disputed finding](https://github.com/hermes-labs-ai/lintlang/issues)
 - [Security policy](SECURITY.md)
+
+## Citation
+
+H1.6's method is described in a technical note:
+
+Bosch, R. (2026). *Tool Differentia: Relational Static Analysis for AI Agent
+Tool Descriptions.* Zenodo.
+[10.5281/zenodo.21817244](https://doi.org/10.5281/zenodo.21817244)
+
+```bibtex
+@misc{bosch2026tooldifferentia,
+  author       = {Bosch, Rolando},
+  title        = {Tool Differentia: Relational Static Analysis for AI Agent
+                  Tool Descriptions},
+  year         = {2026},
+  publisher    = {Zenodo},
+  doi          = {10.5281/zenodo.21817244},
+  url          = {https://doi.org/10.5281/zenodo.21817244},
+  note         = {Technical note}
+}
+```
+
+See [hermes-publications/papers/tool-differentia](https://github.com/hermes-labs-ai/hermes-publications/tree/main/papers/tool-differentia)
+for the full evidence boundary.
 
 ## License
 


### PR DESCRIPTION
## Summary
- Adds a Citation section for the published Tool Differentia technical note (DOI 10.5281/zenodo.21817244)
- Reconciles with the concurrently-merged citation link (#35 / commit 0ccda66) by consolidating into one section instead of two, folding in the BibTeX block

## Test plan
- [x] `external-framing-lint.sh` passes
- [x] No duplicate `## Technical note` / `## Citation` sections remain