### PR TITLE
docs: cite Zenodo concept DOIs for the two 2026-08-06 technical notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ documents LintLang H1.6, the bounded pairwise check for tool descriptions that
 do not supply an analyzed distinction from a neighboring tool. It is a
 technical note, not a semantic-equivalence proof or a runtime-selection
 evaluation. Cite the archived Version 1.0 record at
-[10.5281/zenodo.21817244](https://doi.org/10.5281/zenodo.21817244).
+[10.5281/zenodo.21817243](https://doi.org/10.5281/zenodo.21817243).
 
 ## Quick start
 


### PR DESCRIPTION
## What changed

Switches the two 2026-08-06 technical notes from version DOIs to their Zenodo **concept DOIs**:

| Paper | Now cited as |
|---|---|
| Tool Differentia | `10.5281/zenodo.21817243` |
| Behavioral Canarying | `10.5281/zenodo.21818564` |

## Why

Both papers now have two versions on Zenodo (v1.0 and v1.0.1), and Zenodo mints a new DOI for
every version. A version DOI therefore goes stale on each version bump — which is what just
happened: v1.0.1 was published, the website picked up the new version DOIs, and every surface
still pinned to v1.0 fell out of sync.

A concept DOI is version-agnostic and always resolves to the latest version, so this cannot
recur. It also matches what the v1.0.1 PDF cover pages already print about themselves.

## Not changed

- Zenodo **record** URLs (`zenodo.org/records/<id>/files/...`) stay version-pinned. Those are
  record ids, not DOIs; the concept id does not serve files, so rewriting them would break the
  PDF links.
- The four single-version papers are untouched. Their DOIs are already propagated to ORCID and
  to outside citations, and they cannot go stale.
- No paper content, no claims, no version history.

## Verification

- All six concept DOIs resolve (HTTP 200 through `doi.org`).
- Replacement was done by a guarded script matching only the `10.5281/zenodo.<id>` DOI form,
  never the record-URL form.
- Zero stale version DOIs remain; PDF download links confirmed intact.
