### PR TITLE
docs: remove duplicate date-released key in CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -36,4 +36,3 @@ references:
         given-names: "Rolando"
     doi: "10.5281/zenodo.19042469"
     year: 2026
-date-released: "2026-08-04"


### PR DESCRIPTION
`CITATION.cff` declared `date-released` **twice** at the top level — `"2026-08-05"` near the top and `"2026-08-04"` further down, after the `references:` block.

YAML does not error on duplicate keys; it silently keeps the **last** one. So the file recorded `2026-08-04` as the release date for `version: "0.3.8"`, which is wrong.

Removes the stray later duplicate and keeps `2026-08-05`. The `references:` block citing the Taxonomy paper is verified intact.