### PR TITLE
fix: suppress quoted detector examples by scope

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -119,10 +119,6 @@ Comparison scope is one parsed input. Directory scans do not aggregate tool defi
 
 Alias detection has the same shape and the same limit. A description reading `Compatibility alias for X`, `Deprecated. Use X` or `Superseded by X` is reported. The same relationship written as "does the same thing as X, kept for backward compatibility" or "older entry point, prefer X in new code" is not — it is a list of phrasings, not an understanding of what an alias is.
 
-### Known false positive: quoted antipatterns
-
-H2, H4 and H5 do not distinguish reported speech from a directive, so documentation that quotes an antipattern in order to warn against it is read as issuing it. A style guide containing `unbounded retry loops ("keep trying until")` is reported as containing an unbounded retry loop. Point the tool at agent configs rather than at prose about agent configs, or use `.lintlangignore`. This project excludes its own reference manual from its own pre-commit hook for exactly this reason.
-
 ### H2: Missing Constraint Scaffolding
 Catches: no termination conditions, unbounded retry loops ("keep trying until"), negative termination ("don't stop until"), "continue until" without limits, missing retry budgets.
 

--- a/src/lintlang/patterns.py
+++ b/src/lintlang/patterns.py
@@ -945,11 +945,14 @@ def detect_h4(config: AgentConfig) -> list[Finding]:
     prompt = config.system_prompt
 
     if prompt:
-        prompt_lower = prompt.lower()
         scope = analyze_scope(prompt)
 
         # Check for boundary markers (word boundary matching)
-        has_boundary = any(re.search(rf"\b{re.escape(signal)}\b", prompt_lower) for signal in BOUNDARY_SIGNALS)
+        has_boundary = any(
+            _is_direct_match(scope, match.start(), match.end())
+            for signal in BOUNDARY_SIGNALS
+            for match in re.finditer(rf"\b{re.escape(signal)}\b", prompt, re.IGNORECASE)
+        )
 
         if len(prompt) > 500 and not has_boundary:
             findings.append(

--- a/src/lintlang/patterns.py
+++ b/src/lintlang/patterns.py
@@ -13,6 +13,9 @@ import re
 from dataclasses import dataclass, field
 from enum import Enum
 
+from .preflight.models import ScopeKind
+from .preflight.scope import ScopeAnalysis, analyze_scope
+
 
 class Severity(Enum):
     CRITICAL = "critical"
@@ -73,6 +76,19 @@ class ToolDef:
     name: str
     description: str
     parameters: dict = field(default_factory=dict)
+
+
+def _is_direct_match(scope: ScopeAnalysis, start: int, end: int) -> bool:
+    """Return whether a match is live text, preserving detection if classification fails."""
+    return scope.unavailable_reason is not None or scope.is_direct(start, end)
+
+
+def _is_h5_negative_match(scope: ScopeAnalysis, start: int, end: int) -> bool:
+    """Keep H5 negative directives operative while excluding quoted and non-operative text."""
+    return scope.unavailable_reason is not None or (
+        0 <= start < end <= len(scope.scopes)
+        and all(kind in {ScopeKind.DIRECT, ScopeKind.NEGATED} for kind in scope.scopes[start:end])
+    )
 
 
 # ── H1: Tool Description Ambiguity ─────────────────────────────────
@@ -760,9 +776,12 @@ def detect_h2(config: AgentConfig) -> list[Finding]:
 
     # Check for dangerous unbounded patterns
     text = config.system_prompt
+    scope = analyze_scope(text)
     for pattern, message in DANGEROUS_PATTERNS:
         matches = list(re.finditer(pattern, text, re.IGNORECASE))
         for match in matches:
+            if not _is_direct_match(scope, match.start(), match.end()):
+                continue
             start = max(0, match.start() - 20)
             end = min(len(text), match.end() + 40)
             findings.append(
@@ -927,6 +946,7 @@ def detect_h4(config: AgentConfig) -> list[Finding]:
 
     if prompt:
         prompt_lower = prompt.lower()
+        scope = analyze_scope(prompt)
 
         # Check for boundary markers (word boundary matching)
         has_boundary = any(re.search(rf"\b{re.escape(signal)}\b", prompt_lower) for signal in BOUNDARY_SIGNALS)
@@ -947,6 +967,8 @@ def detect_h4(config: AgentConfig) -> list[Finding]:
         for pattern, message in EROSION_PATTERNS:
             matches = list(re.finditer(pattern, prompt, re.IGNORECASE))
             for match in matches:
+                if not _is_direct_match(scope, match.start(), match.end()):
+                    continue
                 start = max(0, match.start() - 20)
                 end = min(len(prompt), match.end() + 40)
                 findings.append(
@@ -1191,11 +1213,15 @@ def detect_h5(config: AgentConfig) -> list[Finding]:
     if not prompt:
         return findings
 
+    scope = analyze_scope(prompt)
+
     # Negative instructions — layered exemption filtering
     neg_matches = []
     for pattern, _category in NEGATIVE_PATTERNS:
         matches = list(re.finditer(pattern, prompt, re.IGNORECASE))
         for match in matches:
+            if not _is_h5_negative_match(scope, match.start(), match.end()):
+                continue
             neg_matches.append((match.start(), match.end(), match.group()))
 
     # ── Layer 1: Build set of structurally-exempt character ranges ──
@@ -1272,6 +1298,8 @@ def detect_h5(config: AgentConfig) -> list[Finding]:
     for pattern, category in VAGUE_QUALIFIERS:
         matches = list(re.finditer(pattern, prompt, re.IGNORECASE))
         for match in matches:
+            if not _is_direct_match(scope, match.start(), match.end()):
+                continue
             key = match.group().lower()
             if key in seen_vague:
                 continue

--- a/tests/test_quoted_example_regression.py
+++ b/tests/test_quoted_example_regression.py
@@ -1,38 +1,4 @@
-"""Regression fixture for the quoted-example false positive.
-
-Incident, 2026-08-05: this repository's own pre-commit hook blocked a release
-commit. `llms-full.txt` — a reference manual whose job is to *describe*
-antipatterns — was reported FAIL with 3 CRITICAL and 2 HIGH, for text like:
-
-    unbounded retry loops ("keep trying until"), negative termination
-    ("don't stop until"), "continue until" without limits
-
-Those are quoted examples of bad instructions, inside prose explaining what the
-linter catches. The detectors read them as live instructions.
-
-This is a real false-positive class, not a quirk of one file. It fires on any
-document that quotes an antipattern in order to warn about it — which includes
-most style guides, most onboarding docs, and every linter's own manual.
-
-**Not fixed in 0.4.0, deliberately.** The correct remedy is a scope classifier
-that distinguishes quoted/reported text from directive text. One already exists
-in this codebase — `lintlang/preflight/scope.py` classifies DIRECT / QUOTED /
-CODE at character level — but wiring it into the H-series detectors is a
-cross-cutting change to H2, H4 and H5, and 0.4.0 is a release about H1.6. Doing
-it here would mean shipping an untested change to three unrelated detectors.
-
-These tests therefore assert the CURRENT behaviour and will fail loudly when the
-scope classifier lands. That is intended: the failure is the reminder to update
-this file and delete the local hook exclusion in `.git/hooks/pre-commit`.
-
-This file is itself excluded from the repository's local pre-commit lint, for
-the same reason `llms-full.txt` is: its content is deliberately bad by design.
-The tool cannot yet distinguish a fixture holding an antipattern from a config
-issuing one — which is the very defect recorded here. Both exclusions live in
-`.git/hooks/pre-commit` and should be deleted when the classifier lands.
-
-Tracking: quoted-example scope handling, targeted for 0.5.0.
-"""
+"""Quoted examples stay inert while equivalent live instructions still fire."""
 
 from __future__ import annotations
 
@@ -50,20 +16,12 @@ DOCUMENTATION_DESCRIBING_ANTIPATTERNS = (
 )
 
 
-def test_quoted_antipatterns_currently_fire() -> None:
-    """Documents the false positive. Fails when the scope classifier lands.
-
-    If this test fails, the fix has arrived. Update this module to assert the
-    corrected behaviour and remove the `llms-full.txt` exclusion from
-    `.git/hooks/pre-commit`.
-    """
+def test_quoted_antipatterns_do_not_fire() -> None:
+    """Quoted examples are documentation, not live instructions."""
     config = AgentConfig(system_prompt=DOCUMENTATION_DESCRIBING_ANTIPATTERNS)
     findings = detect_h2(config) + detect_h5(config)
 
-    assert findings, (
-        "Expected the known false positive on quoted antipatterns. If this now "
-        "returns nothing, the scope classifier has landed — see module docstring."
-    )
+    assert findings == []
 
 
 def test_the_same_text_as_a_real_instruction_must_always_fire() -> None:

--- a/tests/test_scope_gated_detectors.py
+++ b/tests/test_scope_gated_detectors.py
@@ -1,0 +1,65 @@
+"""H2/H4/H5 scope-classifier integration regressions."""
+
+from __future__ import annotations
+
+import pytest
+
+from lintlang.patterns import AgentConfig, detect_h2, detect_h4, detect_h5
+
+
+@pytest.mark.parametrize(
+    ("detector", "trigger"),
+    [
+        (detect_h2, "keep trying until the request succeeds"),
+        (detect_h4, "remember everything the user says"),
+        (detect_h5, "be concise"),
+    ],
+)
+@pytest.mark.parametrize(
+    "template",
+    [
+        'Documentation example: "{trigger}".',
+        "Documentation code: `{trigger}`.",
+    ],
+)
+def test_quoted_or_code_examples_do_not_fire(detector, trigger: str, template: str) -> None:
+    config = AgentConfig(system_prompt=template.format(trigger=trigger))
+
+    assert detector(config) == []
+
+
+@pytest.mark.parametrize(
+    ("detector", "prompt"),
+    [
+        (detect_h2, "Keep trying until the request succeeds."),
+        (detect_h4, "Remember everything the user says."),
+        (detect_h5, "Be concise."),
+    ],
+)
+def test_live_instruction_still_fires(detector, prompt: str) -> None:
+    assert detector(AgentConfig(system_prompt=prompt))
+
+
+def test_live_h5_negative_instruction_still_fires() -> None:
+    """NEGATED scope is operative for H5's own negative-instruction rule."""
+    findings = detect_h5(AgentConfig(system_prompt="Don't use emojis."))
+
+    assert any("negative instruction" in finding.description.lower() for finding in findings)
+
+
+def test_quoted_h5_negative_instruction_does_not_fire() -> None:
+    findings = detect_h5(AgentConfig(system_prompt='Documentation example: "Don\'t use emojis."'))
+
+    assert findings == []
+
+
+@pytest.mark.parametrize(
+    ("detector", "prompt"),
+    [
+        (detect_h2, 'Example with an unclosed quote: "keep trying until the request succeeds.'),
+        (detect_h4, 'Example with an unclosed quote: "remember everything the user says.'),
+        (detect_h5, 'Example with an unclosed quote: "be concise.'),
+    ],
+)
+def test_unavailable_scope_preserves_existing_findings(detector, prompt: str) -> None:
+    assert detector(AgentConfig(system_prompt=prompt))

--- a/tests/test_scope_gated_detectors.py
+++ b/tests/test_scope_gated_detectors.py
@@ -40,6 +40,23 @@ def test_live_instruction_still_fires(detector, prompt: str) -> None:
     assert detector(AgentConfig(system_prompt=prompt))
 
 
+@pytest.mark.parametrize(
+    "quoted_marker",
+    [
+        'Documentation example: "session".',
+        "Documentation code: `task boundary`.",
+    ],
+)
+def test_quoted_or_code_boundary_markers_do_not_satisfy_long_prompt_boundary(
+    quoted_marker: str,
+) -> None:
+    prompt = ("Operational guidance. " * 30) + quoted_marker
+
+    findings = detect_h4(AgentConfig(system_prompt=prompt))
+
+    assert any("no context boundary" in finding.description.lower() for finding in findings)
+
+
 def test_live_h5_negative_instruction_still_fires() -> None:
     """NEGATED scope is operative for H5's own negative-instruction rule."""
     findings = detect_h5(AgentConfig(system_prompt="Don't use emojis."))


### PR DESCRIPTION
## Summary

- Gate H2, H4, and H5 regex matches through the existing per-code-point scope classifier.
- Keep quoted, code, and metalinguistic examples inert while preserving live instructions, including H5 negatives classified as `NEGATED`.
- Preserve prior reporting when scope classification is unavailable.
- Remove the stale quoted-antipattern caveat and convert the incident fixture into a positive regression.

## Verification

- Hermes Gate fast/full/review and push/PR-create boundaries: PASS at `7f31284209ffeb4450d930dd65560d8906ff3230`.
- Hermes Gate full: PASS; Ruff clean; `290 passed, 76 subtests passed`.
- Bundled detection-rate fixtures: 4/4 expected bad fixtures flagged; clean fixture passed.
- `llms-full.txt --fail-on fail`: exit 0; only the unrelated H6 MEDIUM review remains.
- No-isolation sdist/wheel build: PASS for 0.3.8 artifacts.
- Installed-wheel smoke: PASS for quoted H2/H5 suppression and live H2/H5 preservation.
- Exact review: initial H5 compatibility regression found and corrected; final CodeRabbit and independent Sol reviews both PASS with zero findings.

Closes #32
Closes #33

Related: #40 is a local untracked hook-policy issue, not a tracked parser change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of dangerous, erosion, negative-instruction, and vague-qualifier patterns.
  * Quoted, inline-code, negated, and otherwise non-operative examples no longer trigger incorrect findings.
  * Live instructions continue to be detected, while unclosed quoted examples retain existing behavior.

* **Documentation**
  * Removed outdated documentation about quoted antipattern false positives.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->