### PR TITLE
Add CodeMeta metadata

### DIFF
--- a/codemeta.json
+++ b/codemeta.json
@@ -1,5 +1,5 @@
 {
-  "@context": "https://raw.githubusercontent.com/codemeta/codemeta/master/codemeta.jsonld",
+  "@context": "https://w3id.org/codemeta/3.1",
   "@type": "SoftwareSourceCode",
   "name": "lintlang",
   "description": "Static linter for AI agent configs, tool descriptions, and system prompts with zero-LLM CI gating.",

--- a/codemeta.json
+++ b/codemeta.json
@@ -1,0 +1,19 @@
+{
+  "@context": "https://raw.githubusercontent.com/codemeta/codemeta/master/codemeta.jsonld",
+  "@type": "SoftwareSourceCode",
+  "name": "lintlang",
+  "description": "Static linter for AI agent configs, tool descriptions, and system prompts with zero-LLM CI gating.",
+  "codeRepository": "https://github.com/hermes-labs-ai/lintlang",
+  "version": "0.4.0",
+  "license": "https://spdx.org/licenses/Apache-2.0",
+  "programmingLanguage": "Python",
+  "runtimePlatform": "Python >=3.10",
+  "identifier": [
+    "https://doi.org/10.5281/zenodo.20471007",
+    "https://pypi.org/project/lintlang/0.4.0/"
+  ],
+  "author": [{"@type": "Person", "givenName": "Rolando", "familyName": "Bosch Rodriguez", "identifier": "https://orcid.org/0009-0005-4896-1112"}],
+  "dateModified": "2026-08-13T06:08:46Z",
+  "url": "https://pypi.org/project/lintlang/0.4.0/",
+  "keywords": ["static analysis", "agent configuration", "prompt linting", "CI gating", "zero-LLM"]
+}

--- a/tests/test_version_consistency.py
+++ b/tests/test_version_consistency.py
@@ -35,6 +35,7 @@ CHANGELOG = REPO_ROOT / "CHANGELOG.md"
 CITATION = REPO_ROOT / "CITATION.cff"
 README = REPO_ROOT / "README.md"
 ZENODO = REPO_ROOT / ".zenodo.json"
+CODEMETA = REPO_ROOT / "codemeta.json"
 
 
 def _pyproject_version() -> str:
@@ -103,3 +104,21 @@ def test_version_surfaces_match_pyproject_and_release_state():
     assert f"LINTLANG v{packaged}" in readme or f"@v{packaged}" in readme
     assert "LINTLANG v0.2.0" not in readme
     assert "LINTLANG v0.2.1" not in readme
+
+
+def test_codemeta_matches_release_metadata():
+    """CodeMeta must use a stable context and track the packaged release."""
+    packaged = _pyproject_version()
+    citation = CITATION.read_text(encoding="utf-8")
+    codemeta = json.loads(CODEMETA.read_text(encoding="utf-8"))
+
+    repository_match = re.search(r'(?m)^repository-code:\s*["\']?([^"\'\s]+)', citation)
+    assert repository_match, "CITATION.cff has no repository-code field"
+
+    release_url = f"https://pypi.org/project/lintlang/{packaged}/"
+    assert codemeta["@context"] == "https://w3id.org/codemeta/3.1"
+    assert codemeta["@type"] == "SoftwareSourceCode"
+    assert codemeta["version"] == packaged
+    assert codemeta["codeRepository"] == repository_match.group(1)
+    assert codemeta["url"] == release_url
+    assert release_url in codemeta["identifier"]


### PR DESCRIPTION
## What changed

- add a root `codemeta.json` record for LintLang
- pin the stable CodeMeta 3.1 JSON-LD context instead of the mutable upstream `master` context
- identify the current 0.4.0 release, Apache-2.0 license, Python runtime, package URL, DOI, author ORCID, and repository URL
- add a deterministic release-consistency gate for the CodeMeta context, type, package version, repository URL, and versioned PyPI URL

## Why

CodeMeta gives software archives, research-software indexes, and citation tooling a machine-readable description without changing runtime behavior or release artifacts. The consistency gate prevents the new record from silently drifting when LintLang releases change.

## Validation

- JSON syntax and CodeMeta 3.1 JSON-LD expansion passed
- repository, PyPI 0.4.0, GitHub release v0.4.0, license, DataCite DOI, ORCID, and Software Heritage evidence checked
- `uv run --extra dev pytest -q`: 383 passed, 76 subtests passed
- `uv run --extra dev ruff check .`: passed
- `git diff --check`: passed

## Boundary

This PR does not release or publish a package, create or change a DOI, submit LintLang to a registry, or change runtime behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added standardized project metadata, including version, licensing, repository, author, runtime requirements, and publication details.

* **Tests**
  * Added validation to ensure project metadata remains consistent with release, repository, and package information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->