### PR TITLE
Correct v0.4.0 quoted-detector release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,9 +23,11 @@
 
 ### Fixed
 
-- Quoted detector examples, inline code, and fenced code no longer trigger the
-  H4 missing-boundary heuristic merely by describing boundary language. This
-  post-0.3.8 fix was merged separately in PR #41 and remains regression-covered.
+- Quoted detector examples, inline code, fenced code, and metalinguistic
+  descriptions no longer trigger H2, H4, or H5 merely by mentioning detector
+  phrases. Live directives remain reportable, and scope-classification failures
+  preserve prior reporting. This post-0.3.8 fix was merged separately in PR #41
+  and remains regression-covered.
 
 ## [0.3.8] - 2026-08-05
 


### PR DESCRIPTION
## What changed

- correct the v0.4.0 changelog to state that PR #41 scope-gated H2, H4, and H5
- document preserved live-directive reporting and fail-open behavior when scope classification is unavailable

## Why

The existing release note described the post-0.3.8 quoted-scope fix as H4-only. PR #41 and its regression suite cover H2, H4, and H5, so the public changelog underreported the shipped behavior and left issue #34 without an exact evidence-backed closeout.

## User impact

No runtime behavior changes. The public release history now accurately describes the behavior already shipped in v0.4.0.

## Validation

- `uv run --extra dev pytest -q`: 382 passed, 76 subtests passed
- `ruff check .`: passed
- `git diff --check`: passed

Related: #34, #41, #42


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HERM detection to avoid false positives from metalinguistic descriptions.
  * Continued reporting live directives and scope-classification failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->