### PR TITLE
Remove unverifiable CodeMeta timestamp

### DIFF
--- a/codemeta.json
+++ b/codemeta.json
@@ -13,7 +13,6 @@
     "https://pypi.org/project/lintlang/0.4.0/"
   ],
   "author": [{"@type": "Person", "givenName": "Rolando", "familyName": "Bosch Rodriguez", "identifier": "https://orcid.org/0009-0005-4896-1112"}],
-  "dateModified": "2026-08-13T06:08:46Z",
   "url": "https://pypi.org/project/lintlang/0.4.0/",
   "keywords": ["static analysis", "agent configuration", "prompt linting", "CI gating", "zero-LLM"]
 }


### PR DESCRIPTION
## What changed

- remove the optional `dateModified` value from `codemeta.json`

## Why

The timestamp did not match the v0.4.0 commit, GitHub Release creation/publication, or PyPI upload timestamps. Keeping an unverified volatile value would make the new metadata less trustworthy; CodeMeta does not require this optional field.

## Validation

- CodeMeta 3.1 JSON-LD expansion passed
- `uv run --extra dev pytest -q`: 383 passed, 76 subtests passed
- `uv run --extra dev ruff check .`: passed
- `git diff --check`: passed

## Impact

No runtime, package, release, DOI, or registry behavior changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed outdated modification-date metadata from the project information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->