### PR TITLE
Correct LintLang research metadata relationships

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -23,8 +23,13 @@
   "license": "Apache-2.0",
   "related_identifiers": [
     {
-      "identifier": "10.5281/zenodo.19042469",
-      "relation": "references",
+      "identifier": "10.5281/zenodo.19042468",
+      "relation": "isDerivedFrom",
+      "scheme": "doi"
+    },
+    {
+      "identifier": "10.5281/zenodo.21817243",
+      "relation": "isDocumentedBy",
       "scheme": "doi"
     }
   ]

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -34,5 +34,12 @@ references:
     authors:
       - family-names: "Bosch Rodriguez"
         given-names: "Rolando"
-    doi: "10.5281/zenodo.19042469"
+    doi: "10.5281/zenodo.19042468"
+    year: 2026
+  - type: report
+    title: "Tool Differentia: Relational Static Analysis for AI Agent Tool Descriptions"
+    authors:
+      - family-names: "Bosch Rodriguez"
+        given-names: "Rolando"
+    doi: "10.5281/zenodo.21817243"
     year: 2026

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -36,10 +36,13 @@ references:
         given-names: "Rolando"
     doi: "10.5281/zenodo.19042468"
     year: 2026
-  - type: report
+  - type: article
     title: "Tool Differentia: Relational Static Analysis for AI Agent Tool Descriptions"
     authors:
-      - family-names: "Bosch Rodriguez"
+      - family-names: "Bosch"
         given-names: "Rolando"
+        orcid: "https://orcid.org/0009-0005-4896-1112"
+        affiliation: "Hermes Labs"
     doi: "10.5281/zenodo.21817243"
+    url: "https://doi.org/10.5281/zenodo.21817243"
     year: 2026

--- a/README.md
+++ b/README.md
@@ -23,14 +23,20 @@ It flags patterns such as:
 LintLang's default static checks are deterministic and local. They make no LLM,
 API, telemetry, or network calls.
 
+LintLang was developed as the engineering offshoot of
+[A Taxonomy of Epistemic Failure Modes in Large Language Models](https://doi.org/10.5281/zenodo.19042468),
+but its bounded detectors do not claim to implement or validate every failure
+mode in the paper.
+
 ## Technical note
 
 [Tool Differentia: Relational Static Analysis for AI Agent Tool Descriptions](https://hermes-labs.ai/research/tool-differentia)
 documents LintLang H1.6, the bounded pairwise check for tool descriptions that
 do not supply an analyzed distinction from a neighboring tool. It is a
 technical note, not a semantic-equivalence proof or a runtime-selection
-evaluation. Cite the archived Version 1.0 record at
-[10.5281/zenodo.21817243](https://doi.org/10.5281/zenodo.21817243).
+evaluation. Use its version-independent concept DOI,
+[10.5281/zenodo.21817243](https://doi.org/10.5281/zenodo.21817243), for citation;
+the current archived release is Version 1.0.1.
 
 ## Quick start
 


### PR DESCRIPTION
## What changed

- use the taxonomy concept DOI and classify it as `isDerivedFrom`
- document the owner-confirmed taxonomy-to-LintLang engineering lineage with bounded wording
- add Tool Differentia as `isDocumentedBy` and as a scoped CFF report reference
- correct the README wording that described a concept DOI as a Version 1.0 record

## Why

The previous metadata pointed at one taxonomy version with a generic `references` relation and did not encode the paper that explicitly documents LintLang H1.6. That made the scholarly relationships less precise and mislabeled Tool Differentia's concept DOI.

## Impact

The repository now gives future Zenodo deposits and citation consumers directionally accurate, version-independent relationships. LintLang's own citation identity and DOI are unchanged.

## Validation

- `uvx --from cffconvert cffconvert --validate`
- `python -m json.tool .zenodo.json`
- `pytest -q` — 383 passed, 76 subtests passed
- `ruff check src/ tests/`
- `git diff --check`

Primary metadata readback confirmed the two concept records, and the Tool Differentia paper explicitly states that it documents LintLang H1.6.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added background on LintLang’s origins and clarified the scope of its detectors.
  * Updated citation details, including the technical-note DOI and archived Version 1.0.1 reference.
  * Added a new article reference with authorship, DOI, and URL.
* **Chores**
  * Updated archival record identifiers and documentation metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->